### PR TITLE
Add bison and flex to opentegra's dependencies

### DIFF
--- a/x11-drivers/xf86-video-opentegra/xf86-video-opentegra-9999.ebuild
+++ b/x11-drivers/xf86-video-opentegra/xf86-video-opentegra-9999.ebuild
@@ -15,5 +15,5 @@ IUSE=""
 
 RDEPEND="x11-libs/libdrm[video_cards_tegra]
 	>=x11-base/xorg-server-1.11"
-DEPEND="${RDEPEND}"
+DEPEND="${RDEPEND} sys-devel/flex sys-devel/bison"
 


### PR DESCRIPTION
Opentegra require bison and flex for compilation now, hence add them to the build dependencies.