### PR TITLE
Update for mesa-20.0.0-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@ Gentoo overlay for the grate-driver projects. Add the grate-overlay to layman an
 
     layman -f -o https://raw.githubusercontent.com/grate-driver/grate-overlay/master/overlay.xml -a grate-overlay
 
-Add `-vdpau` to `/etc/portage/profile/use.mask`, otherwise portage will ignore vdpau useflag as it is masked by the default ARM profile.
+Add `-vdpau` and `-video_cards_nouveau` to `/etc/portage/profile/use.mask`, otherwise portage will ignore them as they are masked by the default ARM profile.
+
+GL support is lacking, so anything wayland will use the software render.

--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,3 +1,5 @@
+repo-name = grate-overlay
+sync-uri = https://github.com/grate-driver/grate-overlay
+sync-type = git
 masters = gentoo
 thin-manifests = true
-repo-name = grate-overlay

--- a/profiles/arch/arm/use.mask
+++ b/profiles/arch/arm/use.mask
@@ -1,1 +1,2 @@
 -vdpau
+-video_cards_nouveau


### PR DESCRIPTION
Pulled from gentoo/media-libs/mesa-9999.ebuild

tegra now relies on nouveau, so add that to the docs. Plus, some
extra settings to for life without layman.